### PR TITLE
chore: add Claude Code project setup

### DIFF
--- a/.claude/commands/generate-enums.md
+++ b/.claude/commands/generate-enums.md
@@ -1,0 +1,12 @@
+---
+description: Regenera os enums Go (go-enum) a partir das diretivas //go:generate
+---
+
+Regenere os arquivos de enum do projeto.
+
+1. Garanta que o `go-enum` está instalado (`make install-deps` instala junto com o goose).
+2. Rode `go generate ./...` para reprocessar todas as diretivas `//go:generate go-enum`.
+3. Os arquivos `*_enum.go` são **gerados — nunca edite à mão**. Para mudar um enum, altere a anotação `// ENUM(...)` acima do tipo no `model.go` correspondente e regenere.
+4. Rode `go build ./...` depois para confirmar que nada quebrou.
+
+Lembre que os tipos enum também atravessam a fronteira SSR (Go → TS gerado em `ui/src/props/generated.ts`) quando expostos em `lib/ssr/props.go`.

--- a/.claude/commands/new-feature.md
+++ b/.claude/commands/new-feature.md
@@ -1,0 +1,17 @@
+---
+description: Cria o scaffold de um novo módulo de feature (padrão fx) em pkg/
+---
+
+Crie um novo pacote de feature em `pkg/$ARGUMENTS/` seguindo o padrão existente do projeto (use `pkg/event` como referência). Gere:
+
+1. `model.go` — struct GORM embedando `lib/model.Model` + DTO(s) se necessário. Lembre: IDs são `int64` com `json:",string"` e `ts_type:"string"`.
+2. `service.go` — interface `Service` + implementação `<Feature>Service` recebendo `*gorm.DB` via `New<Feature>Service`.
+3. `router.go` — `func Router(server *echo.Echo, ...)` registrando rotas sob `/api/$ARGUMENTS`.
+4. `fx.go` — `func Module() fx.Option` com `fx.Provide` dos construtores e `fx.Invoke(Router)`.
+
+Depois:
+- Registre `$ARGUMENTS.Module()` na lista de módulos em `cmd/root.go`.
+- Se a feature precisar passar dados para uma página SSR, adicione os campos em `lib/ssr/props.go`.
+- Rode `go build ./...` para validar o grafo fx.
+
+Não invente endpoints ou campos: pergunte o que a feature precisa antes de gerar lógica de negócio. O objetivo deste comando é só o scaffold.

--- a/.claude/commands/new-migration.md
+++ b/.claude/commands/new-migration.md
@@ -1,0 +1,12 @@
+---
+description: Cria uma nova migration goose em ./migrations
+---
+
+Crie uma nova migration goose para: $ARGUMENTS
+
+1. Rode `make new-migration migration=<nome_em_snake_case>` para gerar o arquivo `.go` com timestamp em `./migrations`.
+2. Implemente as funções `Up` e `Down` no arquivo gerado (migrations são em Go, não SQL puro — veja exemplos existentes em `./migrations`).
+3. Garanta que o arquivo seja registrado via import side-effect (o pacote `migrations` é importado em `cmd/migrator.go`).
+4. Para testar: `make migrate-status` e depois `make migrate-up` (precisa do Postgres rodando — `docker-compose up -d postgres`).
+
+Sempre implemente o `Down` correspondente ao `Up`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go build:*)",
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(go run:*)",
+      "Bash(go generate:*)",
+      "Bash(go mod:*)",
+      "Bash(go fmt:*)",
+      "Bash(gofmt:*)",
+      "Bash(golangci-lint:*)",
+      "Bash(make:*)",
+      "Bash(docker-compose:*)",
+      "Bash(docker compose:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(mise:*)",
+      "Bash(npm install:*)",
+      "Bash(yarn install:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 ### Project basic ignorable files ###
 \.env.*
 bin/
-.claude/
+.claude/settings.local.json
 
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Sobre o projeto
+
+Tech Agenda é um agregador open source de eventos de tecnologia (DEV, DEVOPS, PRODUCT, DESIGN, MGMT). Backend em Go que serve uma UI React/TypeScript via **SSR** — não é uma SPA separada; o Go renderiza o React no servidor e devolve HTML.
+
+## Comandos
+
+```bash
+make run                      # sobe o serviço (go run main.go) — porta 8000 por padrão
+make migrate-up               # roda migrations pendentes (goose)
+make migrate-status           # status das migrations
+make new-migration migration=nome_da_migration   # cria nova migration .go em ./migrations
+make key-gen                  # gera par de chaves ED25519 para o JWT
+make install-deps             # instala goose e go-enum (necessário para gerar enums)
+
+go test ./...                 # roda todos os testes
+go test ./pkg/event/...       # roda testes de um pacote
+go test -run TestNome ./pkg/event/   # roda um único teste
+
+golangci-lint run             # lint (CI usa golangci-lint v2)
+go generate ./...             # regenera enums (go-enum) a partir das diretivas //go:generate
+```
+
+Postgres local: `docker-compose up -d postgres` (sobe na 5432, auth `trust`). Config vem de variáveis de ambiente — veja `env.example`. O `Makefile` carrega `.env.local` se existir, senão `env.example`.
+
+Dependências de UI: `cd ui && npm install` (ou `yarn`). O `go-react-ssr` cuida do bundling em runtime; não há build separado de frontend em dev.
+
+## Arquitetura
+
+**Injeção de dependência com Uber fx.** `main.go` → `cmd.Execute()` (cobra) → `rootCmd` monta o grafo fx em `cmd/root.go`, registrando cada módulo de `pkg/`. Cada feature em `pkg/<feature>/` expõe um `fx.go` com `Module()` que faz `fx.Provide(...)` dos services/handlers e `fx.Invoke(Router)` para registrar rotas no Echo. **Para adicionar uma feature nova: crie o módulo e registre-o na lista em `cmd/root.go`.**
+
+**Camadas dentro de um pacote** (padrão em `pkg/event`):
+- `model.go` — struct GORM + DTOs; embeda `lib/model.Model`
+- `service.go` — interface `Service` + implementação com `*gorm.DB`
+- `router.go` — registra rotas no `*echo.Echo`
+- `fx.go` — `Module()` que amarra tudo
+- `*_enum.go` / `model_enum.go` — gerado por `go-enum`
+
+**HTTP**: Echo (`lib/server/http.go`). Sessões em cookie (gorilla/sessions) com payload gzipado. OAuth via `markbates/goth` (`pkg/oauth`); `AuthMiddleware` injeta o usuário no `context.Context`, recuperado com `oauth.GetUserFromCtx(ctx)`.
+
+**SSR (ponto mais importante e não óbvio):**
+- Engine em `lib/ssr/ssr.go` (`go-react-ssr`). Frontend em `ui/src`, páginas em `ui/src/pages/*.tsx`.
+- Handlers chamam `engine.SafeRenderRoute(...)` passando `File: "pages/X.tsx"` e `Props: &ssr.Props{...}`. `SafeRenderRoute` tem recuperação de panic com cache do último render bom, e injeta `<base href="/">` para assets resolverem em rotas aninhadas (`/events/:id`).
+- **Contrato Go↔TS**: a struct `ssr.Props` em `lib/ssr/props.go` é a fronteira de dados. Os tipos TS consumidos pelo React são **gerados** em `ui/src/props/generated.ts` — não edite esse arquivo à mão; ele reflete as structs Go (via `tkrajina/typescriptify`). Ao mudar dados passados para uma página, ajuste `Props` e a struct Go correspondente.
+- **IDs como string**: `lib/model.Model` usa `int64` com tags `json:",string"` e `ts_type:"string"` porque IDs de BIGSERIAL podem exceder `Number.MAX_SAFE_INTEGER` do JS. Sempre trate IDs como string no TS e como `int64` no Go.
+
+**Frontend**: React 18 + Tailwind + PrimeReact + Leaflet (mapas de venues). Organização por átomos: `components/` → `molecules/` → `organisms/` → `pages/`.
+
+**Banco**: Postgres via GORM. Migrations em Go com `goose` (`./migrations`, registradas por import em `cmd/migrator.go`). Relações many2many: `events_tags`, `events_venues`. DSN montado em `lib/database.BuildDSN` — usa `DATABASE_URL` se presente, senão monta a partir de campos individuais.
+
+## Convenções
+
+- Logging estruturado com `log/slog`; em handlers use as variantes `*Context` (`slog.ErrorContext(ctx, ...)`).
+- `samber/lo` é usado largamente para utilitários funcionais (`lo.Map`, `lo.IsNotEmpty`, etc.).
+- Enums Go: anote o tipo com `// ENUM(valor1, valor2)` e a diretiva `//go:generate go-enum --marshal --sql -f model.go` no topo; rode `go generate`.
+- Ainda **não há testes** no repositório — o CI roda `go test ./...` mas hoje passa vazio.
+
+## Deploy
+
+Dockerfile multi-stage (Go builder + node para deps de UI). Deploy no Heroku via GitHub Actions (`.github/workflows/`): `on_push` (lint + test), `on_merge_main`, `on_release`. Versão é injetada em build via ldflags em `lib/config.version`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,16 @@ Dependências de UI: `cd ui && npm install` (ou `yarn`). O `go-react-ssr` cuida 
 - Logging estruturado com `log/slog`; em handlers use as variantes `*Context` (`slog.ErrorContext(ctx, ...)`).
 - `samber/lo` é usado largamente para utilitários funcionais (`lo.Map`, `lo.IsNotEmpty`, etc.).
 - Enums Go: anote o tipo com `// ENUM(valor1, valor2)` e a diretiva `//go:generate go-enum --marshal --sql -f model.go` no topo; rode `go generate`.
-- Ainda **não há testes** no repositório — o CI roda `go test ./...` mas hoje passa vazio.
+
+## Testes
+
+**Regra: toda alteração de código deve vir com teste cobrindo a mudança, ao menos de forma unitária.** Antes de concluir qualquer mudança em `.go`:
+1. Verifique se já existe teste cobrindo o comportamento alterado; se não, crie um.
+2. Rode `go test ./...` (ou ao menos o pacote afetado) e garanta que passa.
+3. Para lógica pura (parsing, validação, regras), teste direto. Para código que depende do banco (services com `*gorm.DB`), use a abordagem de `pkg/event/service_sqli_test.go`: conexão GORM sobre `go-sqlmock` em vez de um Postgres real.
+4. Um bom teste deve **falhar** se a mudança for revertida — confirme isso quando o teste guardar uma correção de bug ou de segurança.
+
+A cobertura ainda é inicial (o projeto começou sem testes), então priorize cobrir o que você toca em vez de tentar cobrir tudo de uma vez. O CI roda `go test ./...` em todo push.
 
 ## Deploy
 

--- a/pkg/event/model_enum_test.go
+++ b/pkg/event/model_enum_test.go
@@ -1,0 +1,49 @@
+package event
+
+import "testing"
+
+// Exemplo de teste-base do projeto: cobre lógica pura (sem banco), exercitando
+// o enum gerado por go-enum. Use-o como ponto de partida para novos testes.
+
+func TestParseEventTypeOf(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    EventTypeOf
+		wantErr bool
+	}{
+		{name: "online", input: "online", want: EventTypeOfOnline},
+		{name: "in_person", input: "in_person", want: EventTypeOfInPerson},
+		{name: "inválido", input: "telepathy", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseEventTypeOf(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("esperava erro para %q, mas não houve", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("erro inesperado: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseEventTypeOf(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEventTypeOfStringRoundTrip(t *testing.T) {
+	for _, v := range []EventTypeOf{EventTypeOfOnline, EventTypeOfInPerson} {
+		parsed, err := ParseEventTypeOf(v.String())
+		if err != nil {
+			t.Fatalf("round-trip falhou para %v: %v", v, err)
+		}
+		if parsed != v {
+			t.Fatalf("round-trip: %v -> %q -> %v", v, v.String(), parsed)
+		}
+	}
+}


### PR DESCRIPTION
Adds a shared Claude Code setup so the team can collaborate on the codebase with consistent context.

## O que tem
- **`CLAUDE.md`** — guia de arquitetura (Uber fx, contrato SSR Go↔TS gerado, IDs `int64`-como-string) e comandos comuns (run, migrations, test, lint, enums).
- **`.claude/`** — `settings.json` com allowlist de permissões + slash commands para os fluxos repetitivos: `/new-feature` (scaffold de módulo fx), `/new-migration`, `/generate-enums`.
- **`.gitignore`** — passa a ignorar só `.claude/settings.local.json` (por-máquina), versionando o resto.
- **Primeiro teste do repo** (`pkg/event/model_enum_test.go`) — lógica pura, sem DB, cobrindo o enum `EventTypeOf`. CI `go test ./...` deixa de passar vazio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)