### PR TITLE
fix: correct .env.local filename typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 osArch:=$(shell uname -a)
 envfile:=.env.local
-ifeq ($(shell test ! -f .env.loical && echo -n yes),yes)
+ifeq ($(shell test ! -f .env.local && echo -n yes),yes)
 	envfile=env.example
 endif
 


### PR DESCRIPTION
A condição de fallback do env-file testava `.env.loical` em vez de `.env.local`, então a lógica de "usar `env.example` só quando `.env.local` não existe" nunca funcionou.

Mudança de 1 linha no `Makefile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)