### PR TITLE
fix: parameterize event query filters to prevent SQL injection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/marcopollivier/techagenda
 go 1.25.5
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/caarlos0/env/v10 v10.0.0 // indirect
 	github.com/evanw/esbuild v0.19.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/caarlos0/env/v10 v10.0.0 h1:yIHUBZGsyqCnpTkbjk8asUlx6RFhhEs+h7TOBdgdzXA=
@@ -163,6 +165,7 @@ github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwA
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/pkg/event/service.go
+++ b/pkg/event/service.go
@@ -73,7 +73,7 @@ func (e *EventService) Get(
 		Limit(limit)
 
 	if lo.IsNotEmpty(name) {
-		base.Where(fmt.Sprintf("title like '%%%s%%'", name))
+		base.Where("title LIKE ?", "%"+name+"%")
 	}
 	if lo.IsNotEmpty(city) {
 		base.Where("venues.city = ?", city)

--- a/pkg/event/service.go
+++ b/pkg/event/service.go
@@ -82,9 +82,9 @@ func (e *EventService) Get(
 		base.Where("tags.tag in ?", tags)
 	}
 	if len(typeOf) > 0 {
-		base.Where(fmt.Sprintf("type_of <@ array[%s]", strings.Join(lo.Map(typeOf, func(i EventTypeOf, _ int) string {
-			return fmt.Sprintf("'%s'::eventtypeof", i.String())
-		}), ",")))
+		placeholders := lo.Map(typeOf, func(_ EventTypeOf, _ int) string { return "?::eventtypeof" })
+		values := lo.Map(typeOf, func(i EventTypeOf, _ int) any { return i.String() })
+		base.Where(fmt.Sprintf("type_of <@ array[%s]", strings.Join(placeholders, ",")), values...)
 	}
 	if available {
 		base.Where("begin_date <= ?", now).Where("end_date > ?", now)

--- a/pkg/event/service_sqli_test.go
+++ b/pkg/event/service_sqli_test.go
@@ -1,0 +1,107 @@
+package event
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// recordingMatcher captures the final SQL string GORM hands to the driver so we
+// can assert how user input is embedded. It matches every query (returns nil)
+// because we only care about inspecting the generated SQL, not enforcing a
+// specific expectation order.
+type recordingMatcher struct {
+	mu   sync.Mutex
+	sqls []string
+}
+
+func (m *recordingMatcher) Match(_, actual string) error {
+	m.mu.Lock()
+	m.sqls = append(m.sqls, actual)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *recordingMatcher) all() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return strings.Join(m.sqls, "\n")
+}
+
+func newMockedService(t *testing.T) (*EventService, *recordingMatcher, sqlmock.Sqlmock) {
+	t.Helper()
+	rec := &recordingMatcher{}
+	mockDB, mock, err := sqlmock.New(
+		sqlmock.QueryMatcherOption(rec),
+		sqlmock.MonitorPingsOption(false),
+	)
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mockDB.Close() })
+
+	// Any number of queries (main + preloads) may run; return empty rows for all
+	// so the call completes without touching a real database.
+	mock.MatchExpectationsInOrder(false)
+	for i := 0; i < 8; i++ {
+		mock.ExpectQuery(".*").WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	}
+
+	gdb, err := gorm.Open(postgres.New(postgres.Config{Conn: mockDB}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("gorm.Open: %v", err)
+	}
+	return NewEventService(gdb).(*EventService), rec, mock
+}
+
+// TestGet_NameFilterIsParameterized proves the user-supplied `name` filter is
+// bound as a query parameter instead of being interpolated into the SQL string.
+// Before the fix, the payload below would have appeared verbatim in the SQL.
+func TestGet_NameFilterIsParameterized(t *testing.T) {
+	svc, rec, _ := newMockedService(t)
+
+	const payload = "x%' OR '1'='1"
+	if _, err := svc.Get(context.Background(), payload, "", nil, nil, false, 0, 10); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	sql := rec.all()
+	if sql == "" {
+		t.Fatal("no SQL was captured")
+	}
+	if strings.Contains(sql, payload) {
+		t.Fatalf("injection payload leaked into SQL string (not parameterized):\n%s", sql)
+	}
+	if !strings.Contains(strings.ToUpper(sql), "TITLE LIKE $") {
+		t.Fatalf("expected a parameterized `title LIKE $N` clause, got:\n%s", sql)
+	}
+}
+
+// TestGet_TypeOfFilterIsParameterized proves the type_of enum values are bound
+// as parameters and only the static `::eventtypeof` casts remain in the SQL.
+func TestGet_TypeOfFilterIsParameterized(t *testing.T) {
+	svc, rec, _ := newMockedService(t)
+
+	typeOf := []EventTypeOf{EventTypeOfOnline, EventTypeOfInPerson}
+	if _, err := svc.Get(context.Background(), "", "", nil, typeOf, false, 0, 10); err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	sql := rec.all()
+	if !strings.Contains(sql, "::eventtypeof") {
+		t.Fatalf("expected the ::eventtypeof cast to remain in SQL, got:\n%s", sql)
+	}
+	for _, literal := range []string{"'online'::eventtypeof", "'in_person'::eventtypeof"} {
+		if strings.Contains(sql, literal) {
+			t.Fatalf("enum value was interpolated as a literal (%s), expected a bound parameter:\n%s", literal, sql)
+		}
+	}
+	if !strings.Contains(sql, "$") {
+		t.Fatalf("expected bound parameters in the type_of clause, got:\n%s", sql)
+	}
+}


### PR DESCRIPTION
O `EventService.Get` montava cláusulas SQL com `fmt.Sprintf`, interpolando valores direto na string.

## Mudanças
- **Filtro `name`** (vinha do query param `?name=`, controlado pelo usuário): agora usa placeholder GORM — `base.Where("title LIKE ?", "%"+name+"%")`. Era um vetor real de SQL injection.
- **Filtro `type_of`**: a parte estática (`?::eventtypeof`) continua montada, mas os valores do enum são bindados como parâmetros em vez de interpolados. Risco menor (valores vêm de enum), mas elimina a interpolação de dados.

Comportamento idêntico ao anterior. `go build ./...` e `go vet ./pkg/event/` passam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)