### PR TITLE
chore: upgrade Docker node base image from EOL 16 to 22 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ ENV CGO_ENABLED=0 GO111MODULE=on GOOS=linux
 RUN go build -a -ldflags "-s -w -X 'github.com/marcopollivier/techagenda/lib/config.version=$VERSION'" -o techagenda .
 
 # Download frontend deps
-FROM node:16-alpine as frontend
+FROM node:22-alpine as frontend
 ADD ./ui /ui
 WORKDIR /ui
 RUN npm install
 
 # Release image layer
-FROM node:16-alpine
+FROM node:22-alpine
 WORKDIR /app
 COPY --from=builder /app/techagenda ./techagenda
 COPY --from=frontend /ui ./ui


### PR DESCRIPTION
Node 16 chegou ao end-of-life em set/2023. Move o stage de dependências do frontend e o stage de runtime para `node:22-alpine` (LTS atual).

Resto do Dockerfile (builder `golang:1.25.5`, layout multi-stage, COPY, CMD) intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)